### PR TITLE
Add session-bus to make system-tray icon work

### DIFF
--- a/com.synology.SynologyDrive.yaml
+++ b/com.synology.SynologyDrive.yaml
@@ -10,8 +10,8 @@ finish-args:
   - --share=network
   - --socket=x11
   - --share=ipc
-  - --talk-name=org.kde.StatusNotifierWatcher
-  - --talk-name=org.freedesktop.Notifications
+  # Need for system tray icon to work
+  - --socket=session-bus
 modules:
   - name: synology-drive
     buildsystem: simple

--- a/com.synology.SynologyDrive.yaml
+++ b/com.synology.SynologyDrive.yaml
@@ -13,7 +13,7 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications
   # Need for system tray icon to work
-  - --socket=session-bus
+  - --own-name=org.kde.StatusNotifierItem-7-1
 modules:
   - name: synology-drive
     buildsystem: simple

--- a/com.synology.SynologyDrive.yaml
+++ b/com.synology.SynologyDrive.yaml
@@ -10,6 +10,8 @@ finish-args:
   - --share=network
   - --socket=x11
   - --share=ipc
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.Notifications
   # Need for system tray icon to work
   - --socket=session-bus
 modules:


### PR DESCRIPTION
Add session-bus to make system-tray icon work.

https://github.com/flathub/com.synology.SynologyDrive/pull/8
Not sure if it is also relate. https://github.com/flathub/com.synology.SynologyDrive/issues/9