### PR TITLE
Add StartupWMClass to .desktop file

### DIFF
--- a/com.synology.SynologyDrive.desktop
+++ b/com.synology.SynologyDrive.desktop
@@ -6,3 +6,4 @@ Icon=com.synology.SynologyDrive
 Terminal=false
 Type=Application
 Categories=Network;FileTransfer;
+StartupWMClass=cloud-drive-ui


### PR DESCRIPTION
This prevents the dock icon from getting duplicated on elementaryOS.

Please see this issue for background information: https://github.com/elementary/dock/issues/64