### PR TITLE
Bump org.freedesktop.Sdk dependency to 22.08

### DIFF
--- a/com.synology.SynologyDrive.yaml
+++ b/com.synology.SynologyDrive.yaml
@@ -1,7 +1,7 @@
 app-id: com.synology.SynologyDrive
 default-branch: stable
 runtime: org.freedesktop.Sdk
-runtime-version: '20.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: synology-drive
 tags: [proprietary]


### PR DESCRIPTION
This increases security and usability, since the old version (20.08) that is currently being used is EOL and does not receive any more updates or fixes.