### PR TITLE
Update the Freedesktop SDK to version 23.08

### DIFF
--- a/com.synology.SynologyDrive.yaml
+++ b/com.synology.SynologyDrive.yaml
@@ -1,7 +1,7 @@
 app-id: com.synology.SynologyDrive
 default-branch: stable
 runtime: org.freedesktop.Sdk
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: synology-drive
 tags: [proprietary]


### PR DESCRIPTION
This updates the Freedesktop SDK to the newly released version 23.08. Just maintenance and shouldn't change anything for the end user.