### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/com.synology.SynologyDrive.yaml
+++ b/com.synology.SynologyDrive.yaml
@@ -12,8 +12,6 @@ finish-args:
   - --share=ipc
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications
-  # Need for system tray icon to work
-  - --own-name=org.kde.*
 modules:
   - name: synology-drive
     buildsystem: simple


### PR DESCRIPTION
This is no longer required with any supported runtimes

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025