### PR TITLE
Add sha test ci

### DIFF
--- a/.github/workflows/deb-sha-test.yml
+++ b/.github/workflows/deb-sha-test.yml
@@ -1,0 +1,20 @@
+name: Deb sha test
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install pipenv
+        run: pip install pipenv
+      - name: Run tests
+        run: |
+          cd tests
+          pipenv install
+          pipenv run pytest

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+/.synology-drive.deb

--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[scripts]
+tests = "pytest"
+
+[packages]
+pyyaml = "*"
+pytest = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.11"

--- a/tests/Pipfile.lock
+++ b/tests/Pipfile.lock
@@ -1,0 +1,109 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "bcf62c3d34ffe862fbad0672bff16f3e9f1e0b788dc41523de624a745899fd6a"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.11"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "iniconfig": {
+            "hashes": [
+                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
+                "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.2"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12",
+                "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.3.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac",
+                "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"
+            ],
+            "index": "pypi",
+            "version": "==7.4.3"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5",
+                "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc",
+                "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df",
+                "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741",
+                "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206",
+                "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27",
+                "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595",
+                "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62",
+                "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98",
+                "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696",
+                "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290",
+                "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9",
+                "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d",
+                "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6",
+                "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867",
+                "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47",
+                "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486",
+                "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6",
+                "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3",
+                "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007",
+                "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938",
+                "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0",
+                "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c",
+                "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735",
+                "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d",
+                "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28",
+                "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4",
+                "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba",
+                "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
+                "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5",
+                "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd",
+                "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3",
+                "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0",
+                "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515",
+                "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c",
+                "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c",
+                "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924",
+                "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34",
+                "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43",
+                "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859",
+                "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673",
+                "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54",
+                "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a",
+                "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b",
+                "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab",
+                "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa",
+                "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c",
+                "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585",
+                "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d",
+                "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"
+            ],
+            "index": "pypi",
+            "version": "==6.0.1"
+        }
+    },
+    "develop": {}
+}

--- a/tests/test_deb_sha.py
+++ b/tests/test_deb_sha.py
@@ -1,0 +1,27 @@
+import hashlib
+import yaml
+from urllib.request import urlretrieve
+
+def test_deb_sha():
+    # Read yaml file
+    with open('../com.synology.SynologyDrive.yaml', 'r', encoding="utf-8") as fileYaml:
+        appYaml = yaml.safe_load(fileYaml)
+
+        # Retrieve url and sha
+        debUrl = ""
+        debSha256 = ""
+        sources = appYaml['modules'][0]["sources"]
+        for source in sources:
+            if "filename" in source and source["filename"] == "synology-drive.deb":
+                debUrl = source["url"]
+                debSha256 = source["sha256"]
+                break
+        
+        # Download deb
+        urlretrieve(debUrl, ".synology-drive.deb")
+
+        # Open deb
+        with open('.synology-drive.deb', 'rb') as fileDeb:
+            b = fileDeb.read()
+            readable_hash = hashlib.sha256(b).hexdigest()
+            assert readable_hash == debSha256

--- a/tests/test_deb_sha.py
+++ b/tests/test_deb_sha.py
@@ -1,27 +1,37 @@
+"""Module providing hash functions."""
 import hashlib
-import yaml
 from urllib.request import urlretrieve
+import os
+import yaml
 
 def test_deb_sha():
-    # Read yaml file
-    with open('../com.synology.SynologyDrive.yaml', 'r', encoding="utf-8") as fileYaml:
-        appYaml = yaml.safe_load(fileYaml)
+	"""Test that the deb file has the correct sha256 and size as discribed"""
 
-        # Retrieve url and sha
-        debUrl = ""
-        debSha256 = ""
-        sources = appYaml['modules'][0]["sources"]
-        for source in sources:
-            if "filename" in source and source["filename"] == "synology-drive.deb":
-                debUrl = source["url"]
-                debSha256 = source["sha256"]
-                break
-        
-        # Download deb
-        urlretrieve(debUrl, ".synology-drive.deb")
+	# Read yaml file
+	with open('../com.synology.SynologyDrive.yaml', 'r', encoding="utf-8") as file_yaml:
+		app_yaml = yaml.safe_load(file_yaml)
 
-        # Open deb
-        with open('.synology-drive.deb', 'rb') as fileDeb:
-            b = fileDeb.read()
-            readable_hash = hashlib.sha256(b).hexdigest()
-            assert readable_hash == debSha256
+		# Retrieve url and sha
+		deb_url = ""
+		deb_sha_256 = ""
+		deb_size = 0
+		sources = app_yaml['modules'][0]["sources"]
+		for source in sources:
+			if "filename" in source and source["filename"] == "synology-drive.deb":
+				deb_url = source["url"]
+				deb_sha_256 = source["sha256"]
+				deb_size = source["size"]
+				break
+
+		# Download deb
+		urlretrieve(deb_url, ".synology-drive.deb")
+
+		# Test file size deb
+		size = os.path.getsize(".synology-drive.deb")
+		assert size == deb_size
+
+		# Test hash deb
+		with open('.synology-drive.deb', 'rb') as file_deb:
+			b = file_deb.read()
+			readable_hash = hashlib.sha256(b).hexdigest()
+			assert readable_hash == deb_sha_256


### PR DESCRIPTION
This tests if the metadata corresponds with the deb file.

```yaml
      - type: extra-data
        filename: synology-drive.deb
        only-arches: [x86_64]
        url: https://global.synologydownload.com/download/Utility/SynologyDriveClient/3.3.0-15082/Ubuntu/Installer/x86_64/synology-drive-client-15082.x86_64.deb
        sha256: 85adca4691084fbc3aa54554c19574d755b517fbff84dabd7f702b7f35346467
        size: 101062840
```

1. Reads the yaml file
2. Downloads the deb
3. Checks the file size
4. Checks the file sha256

To run this for your self run:
```
cd tests
pipenv install
pipenv run pytest
```