### PR TITLE
Add persist flag

### DIFF
--- a/com.synology.SynologyDrive.yaml
+++ b/com.synology.SynologyDrive.yaml
@@ -10,7 +10,7 @@ finish-args:
   - --share=network
   - --socket=x11
   - --share=ipc
-  - --persist=.sabnzbd
+  - --persist=.SynologyDrive
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications
   # Need for system tray icon to work

--- a/com.synology.SynologyDrive.yaml
+++ b/com.synology.SynologyDrive.yaml
@@ -13,6 +13,7 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications
   # Need for system tray icon to work
+  - --persist=.sabnzbd
   - --own-name=org.kde.*
 modules:
   - name: synology-drive

--- a/com.synology.SynologyDrive.yaml
+++ b/com.synology.SynologyDrive.yaml
@@ -10,10 +10,10 @@ finish-args:
   - --share=network
   - --socket=x11
   - --share=ipc
+  - --persist=.sabnzbd
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications
   # Need for system tray icon to work
-  - --persist=.sabnzbd
   - --own-name=org.kde.*
 modules:
   - name: synology-drive


### PR DESCRIPTION
This helps to keep Drive making files in your home directory.

I have removed the home folder permission with Flatseal, however this prevents the Synology Drive from working, because it cannot make a `~/.SynologyDrive`. This will force creating within the `~/.var` app-directory instead.

Let me know if you have any questions. :)