### PR TITLE
Extract the deb-package in apply_extra with bsdtar instead of ar

### DIFF
--- a/com.synology.SynologyDrive.yaml
+++ b/com.synology.SynologyDrive.yaml
@@ -25,15 +25,12 @@ modules:
       - install -Dm644 synologydrive-128.png /app/share/icons/hicolor/128x128/apps/com.synology.SynologyDrive.png
       - install -Dm644 synologydrive-256.png /app/share/icons/hicolor/256x256/apps/com.synology.SynologyDrive.png
       - install -D apply_extra -t /app/bin
-      - cp /usr/bin/ar /app/bin
+      - cp /usr/bin/bsdtar /app/bin
     sources:
       - type: script
         dest-filename: apply_extra
         commands:
-          - ar x synology-drive.deb
-          - tar xf data.tar.xz
-          - mv opt/Synology/SynologyDrive SynologyDrive
-          - rm -r synology-drive.deb control.tar.gz data.tar.xz debian-binary usr
+          - bsdtar -Oxf synology-drive.deb 'data.tar.*' | bsdtar -xf - --strip-components=3 --exclude='./usr'
       - type: file
         path: synology-drive.sh
       - type: file


### PR DESCRIPTION
There seems to be a error with a shared library (libbfd) when extracting the deb-package with `ar` in the `apply_extract` script. The issue is described by #44.

This MR replaces `ar` with `bsdtar` which is also available in `org.freedesktop.Sdk`. This also shrinks the `apply_extra` script down because we can use `bsdtar` to only extract the files we want.

Something similar has been done in the past for flathub/com.microsoft.Teams#59

Let me know what you think.

Closes #44